### PR TITLE
Added instruction cache barriers whenever the pagetable changes.

### DIFF
--- a/kernel/riscv.h
+++ b/kernel/riscv.h
@@ -346,6 +346,9 @@ sfence_vma()
   asm volatile("sfence.vma zero, zero");
 }
 
+/// call after changing executable code in memory to flush instruction caches
+#define instruction_memory_barrier() asm volatile("fence.i")
+
 typedef uint64 pte_t;
 typedef uint64 *pagetable_t; // 512 PTEs
 

--- a/kernel/trampoline.S
+++ b/kernel/trampoline.S
@@ -91,6 +91,9 @@ uservec:
         # install the kernel page table.
         csrw satp, t1
 
+        # flush the instruction cache now that the code changed by updating the page tabe
+        fence.i
+
         # flush now-stale user entries from the TLB.
         sfence.vma zero, zero
 
@@ -107,6 +110,10 @@ userret:
         # switch to the user page table.
         sfence.vma zero, zero
         csrw satp, a0
+
+        # flush the instruction cache now that the code changed by updating the page tabe
+        fence.i
+
         sfence.vma zero, zero
 
         li a0, TRAPFRAME

--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -66,6 +66,11 @@ kvminithart()
 
   w_satp(MAKE_SATP(kernel_pagetable));
 
+  // Depending on the cpu implementation a memory barrier might
+  // not affect the instruction caches, so after loading executable
+  // code an instruction memory barrier is needed.
+  instruction_memory_barrier();
+
   // flush stale entries from the TLB.
   sfence_vma();
 }


### PR DESCRIPTION
Switching between user processes can lead to the memory map and data caches being updated / flushed, but the instruction cache can still hold instructions from the wrong app.
Kernel and user code are mapped at different locations and can not collide, but always flushing the cashes on page table changes is simpler than tracking which core already ran which user app.

Fixes issue #3 .